### PR TITLE
fixing stub search from dashboard

### DIFF
--- a/src/Controller/Therapy/StubController.php
+++ b/src/Controller/Therapy/StubController.php
@@ -67,7 +67,7 @@ class StubController extends AbstractController
     public function searchRedirector(Request $request): Response
     {
         $searchValue = $request->get('searchName_stub');
-        $searchCriteria = $request->get('searchCriteria');
+        $searchCriteria = $request->get('searchCriteria','all');
           
         $sortField = $request->get('sort','id');
         $direction = $request->get('direction', 'asc'); 


### PR DESCRIPTION
it should work now as it assume that searching from dashboard use the criteria 'ALL' by default 