### PR TITLE
adding drag n drop and a-z sort in label edit and therapy schemes

### DIFF
--- a/migrations/Version20240123210342.php
+++ b/migrations/Version20240123210342.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20240123210342 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE label_stub DROP FOREIGN KEY FK_36FA08E9E942160A');
+        $this->addSql('ALTER TABLE label_stub DROP FOREIGN KEY FK_36FA08E933B92F39');
+        $this->addSql('ALTER TABLE label_stub ADD id INT AUTO_INCREMENT NOT NULL, ADD position INT DEFAULT 0 NOT NULL, DROP PRIMARY KEY, ADD PRIMARY KEY (id)');
+        $this->addSql('ALTER TABLE label_stub ADD CONSTRAINT FK_36FA08E9E942160A FOREIGN KEY (stub_id) REFERENCES stub (id)');
+        $this->addSql('ALTER TABLE label_stub ADD CONSTRAINT FK_36FA08E933B92F39 FOREIGN KEY (label_id) REFERENCES label (id)');
+    }
+
+    public function down(Schema $schema): void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE label_stub MODIFY id INT NOT NULL');
+        $this->addSql('ALTER TABLE label_stub DROP FOREIGN KEY FK_36FA08E933B92F39');
+        $this->addSql('ALTER TABLE label_stub DROP FOREIGN KEY FK_36FA08E9E942160A');
+        $this->addSql('DROP INDEX `PRIMARY` ON label_stub');
+        $this->addSql('ALTER TABLE label_stub DROP id, DROP position');
+        $this->addSql('ALTER TABLE label_stub ADD CONSTRAINT FK_36FA08E933B92F39 FOREIGN KEY (label_id) REFERENCES label (id) ON DELETE CASCADE');
+        $this->addSql('ALTER TABLE label_stub ADD CONSTRAINT FK_36FA08E9E942160A FOREIGN KEY (stub_id) REFERENCES stub (id) ON DELETE CASCADE');
+        $this->addSql('ALTER TABLE label_stub ADD PRIMARY KEY (label_id, stub_id)');
+    }
+}

--- a/migrations/Version20240207211937.php
+++ b/migrations/Version20240207211937.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20240207211937 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE scheme ADD stubs_order LONGTEXT NOT NULL COMMENT \'(DC2Type:json)\'');
+    }
+
+    public function down(Schema $schema): void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE scheme DROP stubs_order');
+    }
+}

--- a/src/Controller/Therapy/LabelController.php
+++ b/src/Controller/Therapy/LabelController.php
@@ -110,15 +110,20 @@ class LabelController extends AbstractController
             $orderArray = explode(',', $labelForm->get('stubsOrder')->getData());
 
             // Iterate over the array
+
+
             foreach ($orderArray as $index => $stubId) {
                 // Find the corresponding label_stub record
-                $labelStub = $this->entityManager->getRepository(LabelStub::class)->findOneBy(['stub' => $stubId]);
+                if( $stubId ) {
 
-                // Update the position
-                $labelStub->setPosition($index + 1);
-
-                // Persist the changes
-                $this->entityManager->persist($labelStub);
+                    $labelStub = $this->entityManager->getRepository(LabelStub::class)->findOneBy(['stub' => $stubId]);
+                    
+                    // Update the position
+                    $labelStub->setPosition($index + 1);
+    
+                    // Persist the changes
+                    $this->entityManager->persist($labelStub);
+                }
             }
             
             $this->entityManager->persist($label);

--- a/src/Controller/Therapy/LabelController.php
+++ b/src/Controller/Therapy/LabelController.php
@@ -4,6 +4,7 @@ namespace App\Controller\Therapy;
 
 use App\Entity\Therapy\Label;
 use App\Entity\Therapy\Stub;
+use App\Entity\Therapy\LabelStub;
 use App\Form\Therapy\LabelType;
 use App\Repository\Therapy\LabelRepository;
 use Doctrine\ORM\EntityManagerInterface;
@@ -95,7 +96,7 @@ class LabelController extends AbstractController
             // TODO throw exception
         }
 
-        $stubs =  $label->getStubs();
+        $stubs =  $label->getStubsSortedByPosition();
 
         $labelForm = $this->createForm(LabelType::class, $label);
         $labelForm->handleRequest($request);
@@ -105,6 +106,20 @@ class LabelController extends AbstractController
             
             $label->setShortName($data->getShortName());
             $label->setReportName($data->getReportName());
+
+            $orderArray = explode(',', $labelForm->get('stubsOrder')->getData());
+
+            // Iterate over the array
+            foreach ($orderArray as $index => $stubId) {
+                // Find the corresponding label_stub record
+                $labelStub = $this->entityManager->getRepository(LabelStub::class)->findOneBy(['stub' => $stubId]);
+
+                // Update the position
+                $labelStub->setPosition($index + 1);
+
+                // Persist the changes
+                $this->entityManager->persist($labelStub);
+            }
             
             $this->entityManager->persist($label);
             $this->entityManager->flush();

--- a/src/Controller/Therapy/SchemeController.php
+++ b/src/Controller/Therapy/SchemeController.php
@@ -164,22 +164,24 @@ class SchemeController extends AbstractController
         $selectedLabels = $requestData['selectedLabels'];
         $currentComments = $requestData['currentComments'];
         $notCheckedCheckboxes = $requestData['notCheckedCheckboxes'];
+        $stubsOrder = $requestData['stubsOrder'];
         $suppress = $requestData['suppress'];
         $excerpt = $requestData['excerpt'];
-
-
+            
         $reportContent = $schemeService->generatePDFReport(
             $selectedLabels,
             $suppress,
             $currentComments,
             $notCheckedCheckboxes,
+            $stubsOrder,
             $excerpt
         );
+        
 
         $session = $request->getSession();
         $session->set('reportContent', $reportContent);
         $session->set('reportExcerpt', $excerpt);
-
+        
         return new JsonResponse(['success' => true], 200);
     }
 
@@ -360,7 +362,7 @@ class SchemeController extends AbstractController
     {
         $session = $request->getSession();
         $reportContent = $session->get('reportContent');
-        $reportExcerpt = $session->get('reportExcerpt');
+        $reportExcerpt = $session->get('reportExcerpt');        
         if (!$reportContent) {
             return $this->redirectToRoute('app_therapy_scheme_create');
         }

--- a/src/Controller/Therapy/SchemeController.php
+++ b/src/Controller/Therapy/SchemeController.php
@@ -52,26 +52,30 @@ class SchemeController extends AbstractController
             $targets = json_decode($formData['targets'], true);
             $scheme->setTargets($targets);
 
-            $comments = json_decode($formData['comments'], true);
-            if ($comments === null) {
-                $comments = [];
-            }
-            $scheme->setComments($comments);
+            $stubsOrder = json_decode($formData['stubsOrder'], true);
 
+            if ($stubsOrder === null) {
+                $stubsOrder = [];
+            }
+            $scheme->setStubsOrder($stubsOrder);
+            
+            $comments = json_decode($formData['comments'], true);
+            $scheme->setComments($comments);
+            
             $scheme->setSuppress($formData['suppress']);
             $scheme->setExcerpt($formData['excerpt']);
-
+            
             $scheme->setCreatedAt(new \DateTimeImmutable());
             $scheme->setUpdatedAt(new \DateTimeImmutable());
             $labelIDs = $labels->map(fn (Label $label) => $label->getId())->toArray();
             $scheme->setSelectedLabels($labelIDs);
-
+            
             // * Store the scheme in the session
             $session = $request->getSession();
             $session->set('scheme', $scheme);
             return $this->redirectToRoute('app_therapy_scheme_saveAsTemplate');
         }
-
+        
         return $this->render('therapy/scheme/create.html.twig', [
             'form' => $form->createView(),
         ]);
@@ -129,6 +133,7 @@ class SchemeController extends AbstractController
         $currentLanguage = $requestData['currentLanguage'];
         $currentComments = $requestData['currentComments'];
         $notCheckedCheckboxes = $requestData['notCheckedCheckboxes'];
+        $stubsOrder = $requestData['stubsOrder'];
         $suppress = $requestData['suppress'];
         $excerpt = $requestData['excerpt'];
 
@@ -137,6 +142,7 @@ class SchemeController extends AbstractController
             $suppress,
             $currentComments,
             $notCheckedCheckboxes,
+            $stubsOrder,
             $excerpt,
             $currentLanguage
         );
@@ -186,29 +192,30 @@ class SchemeController extends AbstractController
         LabelService $labelService
     ): Response {
         $currentLanguage = $request->getLocale();
-
+             
         $editedScheme = $schemeRepository->find($id);
-
+        
         $selectedLabels = $editedScheme->getSelectedLabels(); // IDs
-
+        
         // * Going to be used in the form (Entity Type)
         $selectedLabelsEntities = $labelService->getLabelsByIds($selectedLabels);
-
+                  
         $currentComments = $editedScheme->getComments();
         $notCheckedCheckboxes = $editedScheme->getTargets();
-
+        $stubsOrder = $editedScheme->getStubsOrder();
         $suppress = $editedScheme->isSuppress();
         $excerpt = $editedScheme->isExcerpt();
-
+        
         $oldTbody = $schemeService->generateTbody(
             $selectedLabels,
             $suppress,
             $currentComments,
             $notCheckedCheckboxes,
+            $stubsOrder,
             $excerpt,
             $currentLanguage
         );
-
+        
         $form = $this->createForm(EditTherapySchemeType::class, $editedScheme);
         $form->add('labels', EntityType::class, [
             'class' => Label::class,
@@ -217,6 +224,7 @@ class SchemeController extends AbstractController
             'mapped' => false,
             'data' => $selectedLabelsEntities,
         ]);
+        
         $form->handleRequest($request);
 
         if ($form->isSubmitted() && $form->isValid()) {
@@ -226,29 +234,35 @@ class SchemeController extends AbstractController
             if (count($labels) === 0) {
                 return $this->redirect($request->headers->get('referer'));
             }
-
+            
             $updateCurrent = $form->get('updateCurrent')->getData();
-
+            
             if ($updateCurrent) {
                 $scheme = $editedScheme;
             } else {
                 $scheme = new Scheme();
             }
-
+            
             $formData = $form->getData();
-
+            
             $targets = $formData->getTargets();
             $scheme->setTargets($targets);
+            $stubsOrder = $formData->getStubsOrder();
+            if(is_null($stubsOrder)) {
+                $stubsOrder = [];
+            }            
 
+            $scheme->setStubsOrder($stubsOrder);
+                  
             $comments = $formData->getComments();
             $scheme->setComments($comments);
-
+            
             $suppress = $formData->isSuppress();
             $scheme->setSuppress($suppress);
-
+            
             $excerpt = $formData->isExcerpt();
             $scheme->setExcerpt($excerpt);
-
+            
             $scheme->setCreatedAt(new \DateTimeImmutable());
             $scheme->setUpdatedAt(new \DateTimeImmutable());
             $labelIDs = [];
@@ -256,13 +270,14 @@ class SchemeController extends AbstractController
                 $labelIDs[] = $label->getId();
             }
             $scheme->setSelectedLabels($labelIDs);
-
+            
             // * Store the scheme in the session
             $session = $request->getSession();
             $session->set('scheme', $scheme);
+            
             return $this->redirectToRoute('app_therapy_scheme_saveAsTemplate');
         }
-
+         
         return $this->render('therapy/scheme/edit.html.twig', [
             'scheme' => $editedScheme,
             'form' => $form->createView(),
@@ -273,7 +288,7 @@ class SchemeController extends AbstractController
             'selectedLabels' => $selectedLabels
         ]);
     }
-
+    
     #[Route('/{_locale<%app.supported_locales%>}/therapy/scheme/save-as-template', name: 'app_therapy_scheme_saveAsTemplate', methods: ['GET', 'POST'])]
     public function saveAsTemplate(Request $request, SchemeRepository $schemeRepository): Response
     {
@@ -284,19 +299,20 @@ class SchemeController extends AbstractController
         }
         $scheme = new Scheme();
         $scheme->setName('Date: ' . date(DATE_RSS));
-
+        
         $isEditing = $data->getId() != null;
         $toBeUpdatedScheme = null;
-
+        
         if ($isEditing) {
             $toBeUpdatedScheme = $schemeRepository->find($data->getId());
             $scheme->setName($toBeUpdatedScheme->getName());
         }
-
+        
         $form = $this->createForm(SchemeTemplateType::class, $scheme);
         $form->handleRequest($request);
-
+        
         if ($form->isSubmitted() && $form->isValid()) {
+            
             $data->setName($scheme->getName());
             if ($isEditing) {
                 // * Update existing scheme
@@ -304,6 +320,7 @@ class SchemeController extends AbstractController
                 $toBeUpdatedScheme->setSelectedLabels($data->getSelectedLabels());
                 $toBeUpdatedScheme->setTargets($data->getTargets());
                 $toBeUpdatedScheme->setComments($data->getComments());
+                $toBeUpdatedScheme->setStubsOrder($data->getStubsOrder());
                 $toBeUpdatedScheme->setSuppress($data->isSuppress());
                 $toBeUpdatedScheme->setExcerpt($data->isExcerpt());
                 $toBeUpdatedScheme->setUpdatedAt(new \DateTimeImmutable());
@@ -311,7 +328,7 @@ class SchemeController extends AbstractController
                 $this->entityManager->persist($data);
             }
             $this->entityManager->flush();
-
+            
             $session->set('scheme', null);
             return $this->redirectToRoute('app_therapy_scheme_templates_list');
         }

--- a/src/Entity/Therapy/Label.php
+++ b/src/Entity/Therapy/Label.php
@@ -100,7 +100,22 @@ class Label
         $labelStubs = $this->labelStubs->toArray();
 
         usort($labelStubs, function ($a, $b) {
-            return $a->getPosition() <=> $b->getPosition();
+            // Order by position if both positions are not zero.
+            if ($a->getPosition() !== 0 && $b->getPosition() !== 0) {
+                return $a->getPosition() <=> $b->getPosition();
+            }
+    
+            // If one has position not equal to zero, prioritize it.
+            if ($a->getPosition() !== 0) {
+                return -1;
+            }
+    
+            if ($b->getPosition() !== 0) {
+                return 1;
+            }
+    
+            // If both have position equal to zero, maintain their original order.
+            return 0;
         });
 
         $stubs = new ArrayCollection();

--- a/src/Entity/Therapy/Label.php
+++ b/src/Entity/Therapy/Label.php
@@ -21,12 +21,12 @@ class Label
     #[ORM\Column(type: 'string', length: 255, nullable: true)]
     private ?string $reportName;
 
-    #[ORM\ManyToMany(targetEntity: Stub::class, inversedBy: 'labels')]
-    private ?Collection $stubs;
+    #[ORM\OneToMany(mappedBy: "label", targetEntity: LabelStub::class, cascade: ["persist", "remove"])]
+    private ?Collection $labelStubs;
 
     public function __construct()
     {
-        $this->stubs = new ArrayCollection();
+        $this->labelStubs = new ArrayCollection();
     }
 
     public function getId(): ?int
@@ -58,25 +58,76 @@ class Label
         return $this;
     }
 
-    public function getStubs(): Collection
+    public function getLabelStubs(): ?Collection
     {
-        return $this->stubs;
+        return $this->labelStubs;
     }
 
-    public function addStub(Stub $stub): self
+    public function addLabelStub(LabelStub $labelStub): self
     {
-        if (!$this->stubs->contains($stub)) {
-            $this->stubs[] = $stub;
+        if (!$this->labelStubs->contains($labelStub)) {
+            $this->labelStubs[] = $labelStub;
+            $labelStub->setLabel($this);
         }
 
         return $this;
     }
 
-    public function removeStub(Stub $stub): self
+    public function removeLabelStub(LabelStub $labelStub): self
     {
-        $this->stubs->removeElement($stub);
+        if ($this->labelStubs->removeElement($labelStub)) {
+            // set the owning side to null (unless already changed)
+            if ($labelStub->getLabel() === $this) {
+                $labelStub->setLabel(null);
+            }
+        }
 
         return $this;
+    }
+
+    public function getStubs(): Collection
+    {
+        $stubs = new ArrayCollection();
+        foreach ($this->labelStubs as $labelStub) {
+            $stubs[] = $labelStub->getStub();
+        }
+
+        return $stubs;
+    }
+
+    public function getStubsSortedByPosition(): Collection
+    {
+        $labelStubs = $this->labelStubs->toArray();
+
+        usort($labelStubs, function ($a, $b) {
+            return $a->getPosition() <=> $b->getPosition();
+        });
+
+        $stubs = new ArrayCollection();
+        foreach ($labelStubs as $labelStub) {
+            $stubs[] = $labelStub->getStub();
+        }
+
+        return $stubs;
+    }
+
+    public function addStub(Stub $stub): void
+    {
+        $labelStub = new LabelStub();
+        $labelStub->setLabel($this);
+        $labelStub->setStub($stub);
+
+        $this->labelStubs[] = $labelStub;
+    }
+
+    public function deleteStub(Stub $stub): void
+    {
+        foreach ($this->labelStubs as $labelStub) {
+            if ($labelStub->getStub() === $stub) {
+                $this->labelStubs->removeElement($labelStub);
+                break;
+            }
+        }
     }
 
     public function __toString(): string

--- a/src/Entity/Therapy/LabelStub.php
+++ b/src/Entity/Therapy/LabelStub.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace App\Entity\Therapy;
+
+use App\Repository\LabelStubRepository;
+use Doctrine\ORM\Mapping as ORM;
+
+#[ORM\Entity(repositoryClass: LabelStubRepository::class)]
+
+class LabelStub
+{
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column(type: "integer")]
+    private ?int $id;
+
+    #[ORM\ManyToOne(targetEntity: Label::class, inversedBy: "labelStubs")]
+    #[ORM\JoinColumn(nullable: false)]
+    private ?Label $label;
+
+    #[ORM\ManyToOne(targetEntity: Stub::class, inversedBy: "labelStubs")]
+    #[ORM\JoinColumn(nullable: false)]
+    private ?Stub $stub;
+
+    #[ORM\Column(type: 'integer', options: ['default' => '0'])]
+    #[ORM\OrderBy(['position' => 'ASC'])]
+    private ?int $position;
+
+    public function __construct()
+    {
+        // Set a default position, you can modify this based on your logic
+        $this->position = 0;
+    }
+
+
+    // ... additional fields or methods ...
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function getLabel(): ?Label
+    {
+        return $this->label;
+    }
+
+    public function setLabel(?Label $label): self
+    {
+        $this->label = $label;
+
+        return $this;
+    }
+
+    public function getStub(): ?Stub
+    {
+        return $this->stub;
+    }
+
+    public function setStub(?Stub $stub): self
+    {
+        $this->stub = $stub;
+
+        return $this;
+    }
+
+    public function getPosition(): ?int
+    {
+        return $this->position;
+    }
+
+    public function setPosition(?int $position): self
+    {
+        $this->position = $position;
+
+        return $this;
+    }
+}

--- a/src/Entity/Therapy/Scheme.php
+++ b/src/Entity/Therapy/Scheme.php
@@ -37,6 +37,9 @@ class Scheme
     #[ORM\Column]
     private array $selectedLabels = [];
 
+    #[ORM\Column]
+    private ?array $stubsOrder = [];
+
     public function __toString(): string
     {
         return $this->getName();
@@ -139,6 +142,22 @@ class Scheme
     public function setSelectedLabels(array $selectedLabels): self
     {
         $this->selectedLabels = $selectedLabels;
+
+        return $this;
+    }
+
+    public function getStubsOrder(): array
+    {
+        if($this->stubsOrder) {
+            return $this->stubsOrder;
+        } else {
+            return [];
+        }
+    }
+
+    public function setStubsOrder(array $stubsOrder): self
+    {
+        $this->stubsOrder = $stubsOrder;
 
         return $this;
     }

--- a/src/Form/EditTherapySchemeType.php
+++ b/src/Form/EditTherapySchemeType.php
@@ -39,6 +39,11 @@ class EditTherapySchemeType extends AbstractType
                 'label' => false,
                 'attr' => ['style' => 'display:none', 'readonly' => true]
             ])
+            ->add('stubsOrder', TextareaType::class, [
+                'required' => false,    
+                'label' => false,
+                'attr' => ['style' => 'display:none', 'readonly' => true],
+            ])
             ->add("updateCurrent", CheckboxType::class, [
                 'required' => false,
                 'label' => false,
@@ -53,6 +58,10 @@ class EditTherapySchemeType extends AbstractType
         $builder
             ->get('targets')
             ->addModelTransformer(new ArrayToStringTransformer());
+            
+        $builder
+        ->get('stubsOrder')
+        ->addModelTransformer(new ArrayToStringTransformer());
     }
 
 

--- a/src/Form/Therapy/LabelType.php
+++ b/src/Form/Therapy/LabelType.php
@@ -7,6 +7,7 @@ use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\ButtonType;
 use Symfony\Component\Form\Extension\Core\Type\SubmitType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Form\Extension\Core\Type\HiddenType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
@@ -19,6 +20,9 @@ class LabelType extends AbstractType
                 'label' => 'app-therapy-label-edit-form-short-name',
             ])
             ->add('reportName', TextType::class, [
+                'label' => 'app-therapy-label-edit-form-report-name',
+            ])
+            ->add('stubsOrder', HiddenType::class, ['mapped' => false], [
                 'label' => 'app-therapy-label-edit-form-report-name',
             ])
             ->add('save', SubmitType::class, [

--- a/src/Form/TherapySchemeType.php
+++ b/src/Form/TherapySchemeType.php
@@ -43,6 +43,11 @@ class TherapySchemeType extends AbstractType
                 'required' => false,
                 'label' => false,
                 'attr' => ['style' => 'display:none', 'readonly' => true]
+            ])
+            ->add('stubsOrder', TextareaType::class, [
+                'required' => false,
+                'label' => false,
+                'attr' => ['style' => 'display:none', 'readonly' => true]
             ]);
 
     }

--- a/src/Repository/LabelStubRepository.php
+++ b/src/Repository/LabelStubRepository.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace App\Repository;
+
+use App\Entity\Therapy\LabelStub;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+
+/**
+ * @extends ServiceEntityRepository<LabelStub>
+ *
+ * @method LabelStub|null find($id, $lockMode = null, $lockVersion = null)
+ * @method LabelStub|null findOneBy(array $criteria, array $orderBy = null)
+ * @method LabelStub[]    findAll()
+ * @method LabelStub[]    findBy(array $criteria, array $orderBy = null, $limit = null, $offset = null)
+ */
+class LabelStubRepository extends ServiceEntityRepository
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, LabelStub::class);
+    }
+
+    public function save(LabelStub $entity, bool $flush = false): void
+    {
+        $this->getEntityManager()->persist($entity);
+
+        if ($flush) {
+            $this->getEntityManager()->flush();
+        }
+    }
+
+    public function remove(LabelStub $entity, bool $flush = false): void
+    {
+        $this->getEntityManager()->remove($entity);
+
+        if ($flush) {
+            $this->getEntityManager()->flush();
+        }
+    }
+
+//    /**
+//     * @return LabelStub[] Returns an array of LabelStub objects
+//     */
+//    public function findByExampleField($value): array
+//    {
+//        return $this->createQueryBuilder('l')
+//            ->andWhere('l.exampleField = :val')
+//            ->setParameter('val', $value)
+//            ->orderBy('l.id', 'ASC')
+//            ->setMaxResults(10)
+//            ->getQuery()
+//            ->getResult()
+//        ;
+//    }
+
+//    public function findOneBySomeField($value): ?LabelStub
+//    {
+//        return $this->createQueryBuilder('l')
+//            ->andWhere('l.exampleField = :val')
+//            ->setParameter('val', $value)
+//            ->getQuery()
+//            ->getOneOrNullResult()
+//        ;
+//    }
+}

--- a/src/Service/SchemeService.php
+++ b/src/Service/SchemeService.php
@@ -29,7 +29,8 @@ class SchemeService
 
     foreach ($selectedLabels as $labelID) {
       $label = $this->labelRepository->find($labelID);
-      $labelStubs = $label->getStubs();
+
+      $labelStubs = $label->getStubsSortedByPosition();
 
       $trClass = 'table-light hideLabels';
       if ($suppress) {
@@ -119,7 +120,7 @@ class SchemeService
 
     foreach ($selectedLabels as $labelID) {
       $label = $this->labelRepository->find($labelID);
-      $labelStubs = $label->getStubs();
+      $labelStubs = $label->getStubsSortedByPosition();
 
       $trLabel = '';
       if (!$suppress) {

--- a/src/Service/SchemeService.php
+++ b/src/Service/SchemeService.php
@@ -68,13 +68,24 @@ class SchemeService
       $tbodyId = 'oldTbody' . $label->getId();
       $newTbody .= '<tbody id="' . $tbodyId . '" class="sortable">';      
 
+
       $trClass = 'table-light hideLabels filtered';
       if ($suppress) {
-        $trClass .= ' d-none';
+          $trClass .= ' d-none';
       }
       $newTbody .= '<tr class="' . $trClass . '" id="rowLabel|' . $label->getId() . '">' .
-        '<th colspan="5">' . $label->getReportName() . '</th>' .
-        '</tr>';
+          '<th colspan="5">' . $label->getReportName() . '</th>' .
+          '</tr>';
+      
+      // Sorting buttons
+      $newTbody .= '<tr class="sorting-buttons-row filtered">' .
+          '<td colspan="5">' . // Extend colspan to cover all columns
+          '<div class="d-flex justify-content-start">' . // Flex container for left alignment
+          '<button class="btn btn-sm btn-secondary sortAZ me-2" data-tbody="' . $tbodyId . '"><i class="fas fa-sort-alpha-down"></i> A-Z</button>' .
+          '<button class="btn btn-sm btn-secondary sortZA" data-tbody="' . $tbodyId . '"><i class="fas fa-sort-alpha-up"></i> Z-A</button>' .
+          '</div>' .
+          '</td>' .
+          '</tr>';
 
       if (count($labelStubs) > 0) {
         foreach ($labelStubs as $stub) {

--- a/src/Service/SchemeService.php
+++ b/src/Service/SchemeService.php
@@ -29,10 +29,13 @@ class SchemeService
 
     foreach ($selectedLabels as $labelID) {
       $label = $this->labelRepository->find($labelID);
+      
+      $tbodyId = 'oldTbody' . $label->getId();
+      $newTbody .= '<tbody id="' . $tbodyId . '" class="sortable">';      
 
       $labelStubs = $label->getStubsSortedByPosition();
 
-      $trClass = 'table-light hideLabels';
+      $trClass = 'table-light hideLabels filtered';
       if ($suppress) {
         $trClass .= ' d-none';
       }
@@ -103,6 +106,9 @@ class SchemeService
           '</th>' .
           '</tr>';
       }
+
+      $newTbody .= '</tbody>'; // Close the tbody for each label
+
     }
 
     return $newTbody;

--- a/templates/therapy/label/edit.html.twig
+++ b/templates/therapy/label/edit.html.twig
@@ -101,7 +101,6 @@
                 // Handle drag-and-drop reordering
                 var movedItem = evt.from.children[evt.oldIndex];
                 var movedItemId = movedItem.dataset.id;
-                console.log('Reordered!', evt.newIndex, evt.oldIndex, movedItemId);
 
                 // Update the order input value with the new order
                 updateOrderInput();

--- a/templates/therapy/label/edit.html.twig
+++ b/templates/therapy/label/edit.html.twig
@@ -1,42 +1,71 @@
-{% extends 'base.html.twig' %}
+
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>{% block title %}{{ 'app-project-title'|trans }}{% endblock %}</title>
+    <link rel="icon" href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 128 128%22><text y=%221.2em%22 font-size=%2296%22>⚫️</text></svg>">
+
+    <link href="https://cdn.jsdelivr.net/npm/select2@4.1.0-rc.0/dist/css/select2.min.css" rel="stylesheet" />
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.6.4/jquery.min.js" integrity="sha512-pumBsjNRGGqkPzKHndZMaAG+bir374sORyzM3uulLV14lN5LyykqNk8eEeUlUkB3U0M4FApyaHraT65ihJhDpQ==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+    <script src="https://cdn.jsdelivr.net/npm/select2@4.1.0-rc.0/dist/js/select2.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/Sortable/1.14.0/Sortable.min.js"></script>
+
+    {# Run `composer require symfony/webpack-encore-bundle` to start using Symfony UX #}
+    {{ encore_entry_link_tags('app') }}
+    {% block stylesheets %}
+    {% endblock %}
+
+    {{ encore_entry_script_tags('app') }}
+    {% block javascripts %}
+    {% endblock %}
+</head>
+<body>
+
+{% include 'navbar.html.twig' %}
 
 {% block body %}
 <div class="container">
     <h2>{{ 'app-label-edit-page-title'|trans }}</h2>
-    
+
     {{ form_start(labelForm) }}
-        <div>
-            <div class="mb-3">
-                {{ form_label(labelForm.shortName) }}
-                {{ form_widget(labelForm.shortName) }}
-            </div>
-            <div class="mb-3">
-                {{ form_label(labelForm.reportName) }}
-                {{ form_widget(labelForm.reportName) }}
-            </div>
-            <div class="row">
-                <div class="col-1 mb-3">
+    <div>
+        <div class="mb-3">
+            {{ form_label(labelForm.shortName) }}
+            {{ form_widget(labelForm.shortName) }}
+        </div>
+        <div class="mb-3">
+            {{ form_label(labelForm.reportName) }}
+            {{ form_widget(labelForm.reportName) }}
+        </div>
+        <div class="row">
+            <div class="col-1 mb-3">
                 {{ form_widget(labelForm.save) }}
-                </div>
-                <div class="col-2 mb-3">
-                {{ form_widget(labelForm.delete) }}
-                </div>
             </div>
-            <div class="mb-3">
-                    <h3>{{ 'app-therapy-stubs-list-page-title'|trans }}</h3>
-                    <ul>
-                        {% for stub in stubs %}
-                            <li>
-                              <a href="{{ url('app_therapy_stub_edit', {id: stub.id}) }}">
-                                {{ stub.name }}
-                              </a>
-                            </li>
-                        {% endfor %}
-                    </ul>
+            <div class="col-2 mb-3">
+                {{ form_widget(labelForm.delete) }}
             </div>
         </div>
+        <div class="mb-3">
+            <h3>{{ 'app-therapy-stubs-list-page-title'|trans }}</h3>
+            <div class="sorting-options">
+                <button id="sortAZ" class="btn btn-sm btn-secondary">A-Z</button>
+                <button id="sortZA" class="btn btn-sm btn-secondary">Z-A</button>
+            </div>
+            <ul id="sortableList">
+                {% for stub in stubs %}
+                    <li data-id="{{ stub.id }}">
+                        <a href="{{ path('app_therapy_stub_edit', {id: stub.id}) }}">
+                            {{ stub.name }}
+                        </a>
+                    </li>
+                {% endfor %}
+            </ul>
+        </div>
+    </div>
     {{ form_end(labelForm) }}
 </div>
+
 <div {{ stimulus_controller('label-edit', {
     targetUrl: url('app_therapy_label_delete', {id: currentId})
 }) }} class="modal fade" id="confirmModal" tabindex="-1" aria-labelledby="confirmModal" aria-hidden="true">
@@ -56,4 +85,60 @@
         </div>
     </div>
 </div>
+
+<script>
+    document.addEventListener('DOMContentLoaded', function () {
+        var sortableList = document.getElementById('sortableList');
+        var sortAZButton = document.getElementById('sortAZ');
+        var sortZAButton = document.getElementById('sortZA');
+
+        var sortable = new Sortable(sortableList, {
+            animation: 150,
+            onUpdate: function (evt) {
+                // Handle drag-and-drop reordering
+                var movedItem = evt.from.children[evt.oldIndex];
+                var movedItemId = movedItem.dataset.id;
+                console.log('Reordered!', evt.newIndex, evt.oldIndex, movedItemId);
+                // Example: Make an AJAX call to update the order on the server
+                // UpdateOrder(movedItemId, evt.newIndex);
+            },
+        });
+
+        sortAZButton.addEventListener('click', function (event) {
+            event.preventDefault();
+            // Sort the list A-Z by stub name
+            var items = Array.from(sortableList.children);
+            items.sort(function (a, b) {
+                var nameA = a.textContent.trim().toUpperCase();
+                var nameB = b.textContent.trim().toUpperCase();
+                return nameA.localeCompare(nameB);
+            });
+
+            sortableList.innerHTML = '';
+            items.forEach(function (item) {
+                sortableList.appendChild(item);
+            });
+        });
+
+        sortZAButton.addEventListener('click', function (event) {
+            event.preventDefault();
+            // Sort the list Z-A by stub name
+            var items = Array.from(sortableList.children);
+            items.sort(function (a, b) {
+                var nameA = a.textContent.trim().toUpperCase();
+                var nameB = b.textContent.trim().toUpperCase();
+                return nameB.localeCompare(nameA);
+            });
+
+            sortableList.innerHTML = '';
+            items.forEach(function (item) {
+                sortableList.appendChild(item);
+            });
+        });
+    });
+</script>
+
 {% endblock %}
+
+</body>
+</html>

--- a/templates/therapy/label/edit.html.twig
+++ b/templates/therapy/label/edit.html.twig
@@ -38,14 +38,6 @@
             {{ form_label(labelForm.reportName) }}
             {{ form_widget(labelForm.reportName) }}
         </div>
-        <div class="row">
-            <div class="col-1 mb-3">
-                {{ form_widget(labelForm.save) }}
-            </div>
-            <div class="col-2 mb-3">
-                {{ form_widget(labelForm.delete) }}
-            </div>
-        </div>
         <div class="mb-3">
             <h3>{{ 'app-therapy-stubs-list-page-title'|trans }}</h3>
             <div class="sorting-options">
@@ -62,6 +54,16 @@
                 {% endfor %}
             </ul>
         </div>
+        <div class="row">
+            <div class="col-1 mb-3">
+                {{ form_widget(labelForm.save) }}
+            </div>
+            <div class="col-2 mb-3">
+                {{ form_widget(labelForm.delete) }}
+            </div>
+        </div>
+        {{ form_widget(labelForm.stubsOrder, {'attr': {'class': 'sortable-order'}}) }}
+
     </div>
     {{ form_end(labelForm) }}
 </div>
@@ -91,6 +93,7 @@
         var sortableList = document.getElementById('sortableList');
         var sortAZButton = document.getElementById('sortAZ');
         var sortZAButton = document.getElementById('sortZA');
+        var orderInput = document.querySelector('.sortable-order');
 
         var sortable = new Sortable(sortableList, {
             animation: 150,
@@ -99,10 +102,21 @@
                 var movedItem = evt.from.children[evt.oldIndex];
                 var movedItemId = movedItem.dataset.id;
                 console.log('Reordered!', evt.newIndex, evt.oldIndex, movedItemId);
-                // Example: Make an AJAX call to update the order on the server
-                // UpdateOrder(movedItemId, evt.newIndex);
+
+                // Update the order input value with the new order
+                updateOrderInput();
+
             },
         });
+
+        function updateOrderInput() {
+            var items = Array.from(sortableList.children);
+            var order = items.map(function (item) {
+                return item.dataset.id;
+            }).join(',');
+
+            orderInput.value = order;
+        }
 
         sortAZButton.addEventListener('click', function (event) {
             event.preventDefault();
@@ -118,6 +132,9 @@
             items.forEach(function (item) {
                 sortableList.appendChild(item);
             });
+
+            updateOrderInput();
+
         });
 
         sortZAButton.addEventListener('click', function (event) {
@@ -134,6 +151,9 @@
             items.forEach(function (item) {
                 sortableList.appendChild(item);
             });
+
+            updateOrderInput();
+
         });
     });
 </script>

--- a/templates/therapy/scheme/create.html.twig
+++ b/templates/therapy/scheme/create.html.twig
@@ -158,6 +158,40 @@ function initializeSortableForTables() {
     });
 }
 
+function getStubsOrder() {
+    // Get all tbody elements with the class 'sortable'
+    const tbodyElements = document.querySelectorAll('tbody.sortable');
+
+    const labelOrderArray = []; // Define an array to store JSON representations
+
+    tbodyElements.forEach(tbody => {
+        // Get all rows in the current tbody
+        const rows = Array.from(tbody.children);
+
+        const labelOrderMap = new Map(); // Define a map for each tbody
+
+        rows
+            .filter((_, index) => index !== 0) // Skip the first row
+            .forEach(function(row) {
+                const match = row.id.match(/rowLabel\|(\d+)\|stub\|(\d+)/);
+                const labelId = match[1];
+                const stubId = match[2];
+
+                if (!labelOrderMap.has(labelId)) {
+                    labelOrderMap.set(labelId, []);
+                }
+
+                labelOrderMap.get(labelId).push(stubId);
+            });
+
+        // Convert labelOrderMap to JSON and push it to labelOrderArray
+        labelOrderArray.push([...labelOrderMap]);
+    });
+
+    // Return the array if needed
+    return labelOrderArray;
+}
+
 // * A function that returns an array of the comments
 const getCurrentComments = () => {
     const textAreas = document.querySelectorAll("textarea[name^='labelID=']");
@@ -187,24 +221,42 @@ const getNotCheckedCheckboxes = () => {
 
 {# ! Generate the dynamic form #}
 const generateDynamicForm = async (selectedLabels, currentComments, notCheckedCheckboxes, suppress, excerpt) => {
-    const tableBody = document.querySelector("table tbody");
+    // Get all tbody elements
+    const tbodyElements = document.querySelectorAll("table tbody");
+
     if (selectedLabels.length === 0) {
-        tableBody.innerHTML = "";
+        // Clear the content of all tbody elements
+        tbodyElements.forEach(tbody => {
+            tbody.remove();
+        });
     } else {
         const currentLanguage = "{{ app.request.locale }}";
         const url = "{{ path('app_therapy_scheme_generateForm') }}";
+        const stubsOrder = [];
         const requestBody = {
             selectedLabels,
             currentLanguage,
             currentComments,
             notCheckedCheckboxes,
+            stubsOrder,
             suppress,
             excerpt
         };
-        const response = await axios.post(url, requestBody);
 
-        tableBody.outerHTML = response.data;
+        try {
+            // Send a POST request
+            const response = await axios.post(url, requestBody);
 
+            // Remove all existing tbody elements
+            tbodyElements.forEach(tbody => {
+                tbody.remove();
+            });
+
+            // Append new tbody sections from the response HTML
+            document.querySelector("table").insertAdjacentHTML('beforeend', response.data);
+        } catch (error) {
+            console.error("Error:", error);
+        }
     }
 };
 
@@ -315,6 +367,9 @@ $(document).ready(function () {
         const notCheckedCheckboxes = getNotCheckedCheckboxes();
         const targetsInput = document.getElementById("therapy_scheme_targets");
         targetsInput.value = JSON.stringify(notCheckedCheckboxes);
+
+        const stubsOrder = document.getElementById("therapy_scheme_stubsOrder");
+        stubsOrder.value = JSON.stringify(getStubsOrder());
 
         const form = document.getElementById("create_therapy_scheme_form");
         form.submit();

--- a/templates/therapy/scheme/create.html.twig
+++ b/templates/therapy/scheme/create.html.twig
@@ -101,8 +101,10 @@
 {% endblock %}
 {% block javascripts %}
 <script src="https://unpkg.com/axios/dist/axios.min.js"></script>
+<script src="https://unpkg.com/sortablejs@1.14.0/Sortable.min.js"></script>
 
 <script>
+    
 let selectedLabels = [];
 $(document).ready(function () {
     $("#therapy_scheme_labels")
@@ -126,6 +128,7 @@ $(document).ready(function () {
                 const suppress = $("#therapy_scheme_suppress").is(":checked");
                 const excerpt = $("#therapy_scheme_excerpt").is(":checked");
                 await generateDynamicForm(selectedValues, currentComments, notCheckedCheckboxes, suppress, excerpt);
+                initializeSortableForTables();
 
                 {# * Show/hide content #}
                 if (selectedValues.length > 0) {
@@ -138,6 +141,22 @@ $(document).ready(function () {
 
         });
 });
+
+// Function to initialize Sortable for each tbody
+function initializeSortableForTables() {
+    const tbodyElements = document.querySelectorAll('.sortable');
+
+    tbodyElements.forEach(tbody => {
+        const sortable = new Sortable(tbody, {
+            filter: '.filtered',
+            onMove(evt, oe) {
+                // Check if the related element has the class 'filtered'
+                return evt.related.className.indexOf('filtered') === -1;
+            },
+            preventOnFilter: true,
+        });
+    });
+}
 
 // * A function that returns an array of the comments
 const getCurrentComments = () => {
@@ -183,7 +202,9 @@ const generateDynamicForm = async (selectedLabels, currentComments, notCheckedCh
             excerpt
         };
         const response = await axios.post(url, requestBody);
-        tableBody.innerHTML = response.data;
+
+        tableBody.outerHTML = response.data;
+
     }
 };
 

--- a/templates/therapy/scheme/create.html.twig
+++ b/templates/therapy/scheme/create.html.twig
@@ -125,9 +125,10 @@ $(document).ready(function () {
 
                 const currentComments = getCurrentComments();
                 const notCheckedCheckboxes = getNotCheckedCheckboxes();
+                const stubsOrder = getStubsOrder();
                 const suppress = $("#therapy_scheme_suppress").is(":checked");
                 const excerpt = $("#therapy_scheme_excerpt").is(":checked");
-                await generateDynamicForm(selectedValues, currentComments, notCheckedCheckboxes, suppress, excerpt);
+                await generateDynamicForm(selectedValues, currentComments, notCheckedCheckboxes, stubsOrder, suppress, excerpt);
                 initializeSortableForTables();
 
                 {# * Show/hide content #}
@@ -220,7 +221,7 @@ const getNotCheckedCheckboxes = () => {
 };
 
 {# ! Generate the dynamic form #}
-const generateDynamicForm = async (selectedLabels, currentComments, notCheckedCheckboxes, suppress, excerpt) => {
+const generateDynamicForm = async (selectedLabels, currentComments, notCheckedCheckboxes, stubsOrder, suppress, excerpt) => {
     // Get all tbody elements
     const tbodyElements = document.querySelectorAll("table tbody");
 
@@ -232,7 +233,6 @@ const generateDynamicForm = async (selectedLabels, currentComments, notCheckedCh
     } else {
         const currentLanguage = "{{ app.request.locale }}";
         const url = "{{ path('app_therapy_scheme_generateForm') }}";
-        const stubsOrder = [];
         const requestBody = {
             selectedLabels,
             currentLanguage,
@@ -261,7 +261,7 @@ const generateDynamicForm = async (selectedLabels, currentComments, notCheckedCh
 };
 
 {# ! Generate the Report #}
-const generateReport = async (selectedLabels, currentComments, notCheckedCheckboxes, suppress, excerpt) => {
+const generateReport = async (selectedLabels, currentComments, notCheckedCheckboxes, stubsOrder, suppress, excerpt) => {
     if (selectedLabels.length > 0) {
         const currentLanguage = "{{ app.request.locale }}";
         const url = "{{ path('app_therapy_scheme_generateReport') }}";
@@ -270,6 +270,7 @@ const generateReport = async (selectedLabels, currentComments, notCheckedCheckbo
             currentLanguage,
             currentComments,
             notCheckedCheckboxes,
+            stubsOrder,
             suppress,
             excerpt
         };
@@ -378,9 +379,10 @@ $(document).ready(function () {
 	$("#generatePDFButton").click(async function () {
 		const currentComments = getCurrentComments();
 		const notCheckedCheckboxes = getNotCheckedCheckboxes();
+        const stubsOrder = getStubsOrder();
 		const suppress = $("#therapy_scheme_suppress").is(":checked");
 		const excerpt = $("#therapy_scheme_excerpt").is(":checked");
-		const response = await generateReport(selectedLabels, currentComments, notCheckedCheckboxes, suppress, excerpt);
+		const response = await generateReport(selectedLabels, currentComments, notCheckedCheckboxes, stubsOrder, suppress, excerpt);
 		const responseStatus = response.status;
 		if (responseStatus === 200) {
 			const form = document.getElementById("generatePDFForm");
@@ -392,9 +394,10 @@ $(document).ready(function () {
 		e.preventDefault();
 		const currentComments = getCurrentComments();
 		const notCheckedCheckboxes = getNotCheckedCheckboxes();
+        const stubsOrder = getStubsOrder();
 		const suppress = $("#therapy_scheme_suppress").is(":checked");
 		const excerpt = $("#therapy_scheme_excerpt").is(":checked");
-		const response = await generateReport(selectedLabels, currentComments, notCheckedCheckboxes, suppress, excerpt);
+		const response = await generateReport(selectedLabels, currentComments, notCheckedCheckboxes, stubsOrder, suppress, excerpt);
 		const responseStatus = response.status;
 		if (responseStatus === 200) {
 			const generateHTMLLink = document.getElementById("generateHTMLLink");

--- a/templates/therapy/scheme/create.html.twig
+++ b/templates/therapy/scheme/create.html.twig
@@ -102,6 +102,7 @@
 {% block javascripts %}
 <script src="https://unpkg.com/axios/dist/axios.min.js"></script>
 <script src="https://unpkg.com/sortablejs@1.14.0/Sortable.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
 
 <script>
     
@@ -175,14 +176,18 @@ function getStubsOrder() {
             .filter((_, index) => index !== 0) // Skip the first row
             .forEach(function(row) {
                 const match = row.id.match(/rowLabel\|(\d+)\|stub\|(\d+)/);
-                const labelId = match[1];
-                const stubId = match[2];
+                if(match) {
 
-                if (!labelOrderMap.has(labelId)) {
-                    labelOrderMap.set(labelId, []);
+                    const labelId = match[1];
+                    const stubId = match[2];
+
+                    if (!labelOrderMap.has(labelId)) {
+                        labelOrderMap.set(labelId, []);
+                    }
+
+                    labelOrderMap.get(labelId).push(stubId);
+
                 }
-
-                labelOrderMap.get(labelId).push(stubId);
             });
 
         // Convert labelOrderMap to JSON and push it to labelOrderArray
@@ -254,11 +259,61 @@ const generateDynamicForm = async (selectedLabels, currentComments, notCheckedCh
 
             // Append new tbody sections from the response HTML
             document.querySelector("table").insertAdjacentHTML('beforeend', response.data);
+            sortInit();
         } catch (error) {
             console.error("Error:", error);
         }
     }
 };
+
+
+function sortInit() {
+
+    $('.sortAZ').each(function() {
+        $(this).on('click', function(event) {
+            event.preventDefault(); // Prevent the default form submission behavior
+            var tbodyId = $(this).data('tbody');
+            sortTable(tbodyId, 'asc');
+        });
+    });
+
+    $('.sortZA').each(function() {
+        $(this).on('click', function(event) {
+            event.preventDefault(); // Prevent the default form submission behavior
+            var tbodyId = $(this).data('tbody');
+            sortTable(tbodyId, 'desc');
+        });
+    });
+}
+
+function sortTable(tbodyId, order) {
+    var $tbody = $('#' + tbodyId);
+    var rows = $tbody.find('tr').toArray();
+
+    // Exclude the first two rows from sorting
+    var rowsToSort = rows.slice(2);
+
+    rowsToSort.sort(function(a, b) {
+        var nameA = $(a).find('.col-2').text().toUpperCase();
+        var nameB = $(b).find('.col-2').text().toUpperCase();
+        
+        if (order === 'asc') {
+            return nameA.localeCompare(nameB);
+        } else {
+            return nameB.localeCompare(nameA);
+        }
+    });
+
+    // Remove subsequent rows after the second one
+    rows.slice(2).forEach(function(row) {
+        row.remove();
+    });
+
+    // Append the sorted rows after the second row
+    rowsToSort.forEach(function(row) {
+        $tbody.append(row);
+    });
+}
 
 {# ! Generate the Report #}
 const generateReport = async (selectedLabels, currentComments, notCheckedCheckboxes, stubsOrder, suppress, excerpt) => {

--- a/templates/therapy/scheme/edit.html.twig
+++ b/templates/therapy/scheme/edit.html.twig
@@ -129,6 +129,8 @@
 {% block javascripts %}
 <script src="https://unpkg.com/axios/dist/axios.min.js"></script>
 <script src="https://unpkg.com/sortablejs@1.14.0/Sortable.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
+
 
 <script>
 
@@ -151,7 +153,7 @@
 			});
 		});
 	}
-	
+
 	function getStubsOrder() {
 		// Get all tbody elements with the class 'sortable'
 		const tbodyElements = document.querySelectorAll('tbody.sortable');
@@ -168,14 +170,18 @@
 				.filter((_, index) => index !== 0) // Skip the first row
 				.forEach(function(row) {
 					const match = row.id.match(/rowLabel\|(\d+)\|stub\|(\d+)/);
-					const labelId = match[1];
-					const stubId = match[2];
+					if(match) {
 
-					if (!labelOrderMap.has(labelId)) {
-						labelOrderMap.set(labelId, []);
+						const labelId = match[1];
+						const stubId = match[2];
+
+						if (!labelOrderMap.has(labelId)) {
+							labelOrderMap.set(labelId, []);
+						}
+
+						labelOrderMap.get(labelId).push(stubId);
+
 					}
-
-					labelOrderMap.get(labelId).push(stubId);
 				});
 
 			// Convert labelOrderMap to JSON and push it to labelOrderArray
@@ -284,6 +290,9 @@
 
 				// Append new tbody sections from the response HTML
 				document.querySelector("table").insertAdjacentHTML('beforeend', response.data);
+
+				sortInit();
+
 			} catch (error) {
 				console.error("Error:", error);
 			}
@@ -327,6 +336,55 @@
 			const label = "{{ 'app-therapy-report-use-excerpt'|trans }}".replace(replaceString , "'");
 			excerptSwitchLabel.innerText = label;
 	});
+
+
+	function sortInit() {
+
+		$('.sortAZ').each(function() {
+			$(this).on('click', function(event) {
+				event.preventDefault(); // Prevent the default form submission behavior
+				var tbodyId = $(this).data('tbody');
+				sortTable(tbodyId, 'asc');
+			});
+		});
+
+		$('.sortZA').each(function() {
+			$(this).on('click', function(event) {
+				event.preventDefault(); // Prevent the default form submission behavior
+				var tbodyId = $(this).data('tbody');
+				sortTable(tbodyId, 'desc');
+			});
+		});
+	}
+
+	function sortTable(tbodyId, order) {
+		var $tbody = $('#' + tbodyId);
+		var rows = $tbody.find('tr').toArray();
+
+		// Exclude the first two rows from sorting
+		var rowsToSort = rows.slice(2);
+
+		rowsToSort.sort(function(a, b) {
+			var nameA = $(a).find('.col-2').text().toUpperCase();
+			var nameB = $(b).find('.col-2').text().toUpperCase();
+			
+			if (order === 'asc') {
+				return nameA.localeCompare(nameB);
+			} else {
+				return nameB.localeCompare(nameA);
+			}
+		});
+
+		// Remove subsequent rows after the second one
+		rows.slice(2).forEach(function(row) {
+			row.remove();
+		});
+
+		// Append the sorted rows after the second row
+		rowsToSort.forEach(function(row) {
+			$tbody.append(row);
+		});
+	}
 
 	// * Resetting when page is refreshed
 	$(document).ready(function () {

--- a/templates/therapy/scheme/edit.html.twig
+++ b/templates/therapy/scheme/edit.html.twig
@@ -132,9 +132,12 @@
 
 <script>
 
-
 	document.addEventListener('DOMContentLoaded', function() {
-		// Initialize Sortable for each table body
+		initializeSortableForTables();
+	});
+
+	// Function to initialize Sortable for each tbody
+	function initializeSortableForTables() {
 		const tbodyElements = document.querySelectorAll('.sortable');
 
 		tbodyElements.forEach(tbody => {
@@ -147,7 +150,41 @@
 				preventOnFilter: true,
 			});
 		});
-	});
+	}
+	
+	function getStubsOrder() {
+		// Get all tbody elements with the class 'sortable'
+		const tbodyElements = document.querySelectorAll('tbody.sortable');
+
+		const labelOrderArray = []; // Define an array to store JSON representations
+
+		tbodyElements.forEach(tbody => {
+			// Get all rows in the current tbody
+			const rows = Array.from(tbody.children);
+
+			const labelOrderMap = new Map(); // Define a map for each tbody
+
+			rows
+				.filter((_, index) => index !== 0) // Skip the first row
+				.forEach(function(row) {
+					const match = row.id.match(/rowLabel\|(\d+)\|stub\|(\d+)/);
+					const labelId = match[1];
+					const stubId = match[2];
+
+					if (!labelOrderMap.has(labelId)) {
+						labelOrderMap.set(labelId, []);
+					}
+
+					labelOrderMap.get(labelId).push(stubId);
+				});
+
+			// Convert labelOrderMap to JSON and push it to labelOrderArray
+			labelOrderArray.push([...labelOrderMap]);
+		});
+
+		// Return the array if needed
+		return labelOrderArray;
+	}
 
 	let selectedLabels = [];
 	$(document).ready(function () {
@@ -169,10 +206,11 @@
 
 					const currentComments = getCurrentComments();
 					const notCheckedCheckboxes = getNotCheckedCheckboxes();
+					const stubsOrder = getStubsOrder();
 					const suppress = $("#edit_therapy_scheme_suppress").is(":checked");
 					const excerpt = $("#edit_therapy_scheme_excerpt").is(":checked");
-					await generateDynamicForm(selectedValues, currentComments, notCheckedCheckboxes, suppress, excerpt);
-
+					await generateDynamicForm(selectedValues, currentComments, notCheckedCheckboxes, stubsOrder, suppress, excerpt);
+					initializeSortableForTables()
 					{# * Show/hide content #}
 					if (selectedValues.length > 0) {
 						$("#contentDisplayedWhenLabelsAreSelected").removeClass("d-none");
@@ -213,11 +251,15 @@
 	};
 
 
-	// * Generate the dynamic form
-	const generateDynamicForm = async (selectedLabels, currentComments, notCheckedCheckboxes, suppress, excerpt) => {
-		const tableBody = document.querySelector("table tbody");
+	{# ! Generate the dynamic form #}
+	const generateDynamicForm = async (selectedLabels, currentComments, notCheckedCheckboxes, stubsOrder, suppress, excerpt) => {
+		// Get all tbody elements
+		const tbodyElements = document.querySelectorAll("table tbody");
 		if (selectedLabels.length === 0) {
-			tableBody.innerHTML = "";
+			// Clear the content of all tbody elements
+			tbodyElements.forEach(tbody => {
+				tbody.remove();
+			});
 		} else {
 			const currentLanguage = "{{ app.request.locale }}";
 			const url = "{{ path('app_therapy_scheme_generateForm') }}";
@@ -226,22 +268,25 @@
 				currentLanguage,
 				currentComments,
 				notCheckedCheckboxes,
+				stubsOrder,
 				suppress,
 				excerpt
 			};
-			const response = await axios.post(url, requestBody);
-			// Create a temporary div to hold the parsed HTML
-			const tempDiv = document.createElement("div");
-			tempDiv.innerHTML = response.data;
 
-			// Extract all the <tbody> elements
-			const newTbodies = tempDiv.querySelectorAll("tbody");
+			try {
+				// Send a POST request
+				const response = await axios.post(url, requestBody);
 
-			// Replace the existing content of the table body with the new <tbody> elements
-			tableBody.innerHTML = "";
-			newTbodies.forEach((newTbody) => {
-				tableBody.appendChild(newTbody);
-			});
+				// Remove all existing tbody elements
+				tbodyElements.forEach(tbody => {
+					tbody.remove();
+				});
+
+				// Append new tbody sections from the response HTML
+				document.querySelector("table").insertAdjacentHTML('beforeend', response.data);
+			} catch (error) {
+				console.error("Error:", error);
+			}
 		}
 	};
 
@@ -368,10 +413,12 @@
 			// Get the comments and not-checked checkboxes
 			const comments = getCurrentComments();
 			const notCheckedCheckboxes = getNotCheckedCheckboxes();
+			const stubsOrder = getStubsOrder();
 
 			// Set the values of the hidden input fields
 			$("#edit_therapy_scheme_comments").val(JSON.stringify(comments));
 			$("#edit_therapy_scheme_targets").val(JSON.stringify(notCheckedCheckboxes));
+			$("#edit_therapy_scheme_stubsOrder").val(JSON.stringify(stubsOrder));
 
 			// Submit the form
 			$("#edit_create_therapy_scheme_form").submit();

--- a/templates/therapy/scheme/edit.html.twig
+++ b/templates/therapy/scheme/edit.html.twig
@@ -291,7 +291,7 @@
 	};
 
 	// * Generate the Report
-	const generateReport = async (selectedLabels, currentComments, notCheckedCheckboxes, suppress, excerpt) => {
+	const generateReport = async (selectedLabels, currentComments, notCheckedCheckboxes, stubsOrder, suppress, excerpt) => {
 		if (selectedLabels.length > 0) {
 			const currentLanguage = "{{ app.request.locale }}";
 			const url = "{{ path('app_therapy_scheme_generateReport') }}";
@@ -300,10 +300,12 @@
 				currentLanguage,
 				currentComments,
 				notCheckedCheckboxes,
+				stubsOrder,
 				suppress,
 				excerpt
 			};
 			const result = await axios.post(url, requestBody);
+			console.log(result);
 			return result;
 		}
 	};
@@ -430,9 +432,10 @@
 		$("#generatePDFButton").click(async function () {
 			const currentComments = getCurrentComments();
 			const notCheckedCheckboxes = getNotCheckedCheckboxes();
+			const stubsOrder = getStubsOrder();
 			const suppress = $("#edit_therapy_scheme_suppress").is(":checked");
 			const excerpt = $("#edit_therapy_scheme_excerpt").is(":checked");
-			const response = await generateReport(selectedLabels, currentComments, notCheckedCheckboxes, suppress, excerpt);
+			const response = await generateReport(selectedLabels, currentComments, notCheckedCheckboxes, stubsOrder, suppress, excerpt);
 			const responseStatus = response.status;
 			if (responseStatus === 200) {
 				const form = document.getElementById("generatePDFForm");
@@ -444,9 +447,10 @@
 			e.preventDefault();
 			const currentComments = getCurrentComments();
 			const notCheckedCheckboxes = getNotCheckedCheckboxes();
+			const stubsOrder = getStubsOrder();
 			const suppress = $("#edit_therapy_scheme_suppress").is(":checked");
 			const excerpt = $("#edit_therapy_scheme_excerpt").is(":checked");
-			const response = await generateReport(selectedLabels, currentComments, notCheckedCheckboxes, suppress, excerpt);
+			const response = await generateReport(selectedLabels, currentComments, notCheckedCheckboxes, stubsOrder, suppress, excerpt);
 			const responseStatus = response.status;
 			if (responseStatus === 200) {
 				const generateHTMLLink = document.getElementById("generateHTMLLink");

--- a/templates/therapy/scheme/edit.html.twig
+++ b/templates/therapy/scheme/edit.html.twig
@@ -128,8 +128,26 @@
 
 {% block javascripts %}
 <script src="https://unpkg.com/axios/dist/axios.min.js"></script>
+<script src="https://unpkg.com/sortablejs@1.14.0/Sortable.min.js"></script>
 
 <script>
+
+
+	document.addEventListener('DOMContentLoaded', function() {
+		// Initialize Sortable for each table body
+		const tbodyElements = document.querySelectorAll('.sortable');
+
+		tbodyElements.forEach(tbody => {
+			const sortable = new Sortable(tbody, {
+				filter: '.filtered',
+				onMove(evt, oe) {
+					// Check if the related element has the class 'filtered'
+					return evt.related.className.indexOf('filtered') === -1;
+				},
+				preventOnFilter: true,
+			});
+		});
+	});
 
 	let selectedLabels = [];
 	$(document).ready(function () {
@@ -212,7 +230,18 @@
 				excerpt
 			};
 			const response = await axios.post(url, requestBody);
-			tableBody.innerHTML = response.data;
+			// Create a temporary div to hold the parsed HTML
+			const tempDiv = document.createElement("div");
+			tempDiv.innerHTML = response.data;
+
+			// Extract all the <tbody> elements
+			const newTbodies = tempDiv.querySelectorAll("tbody");
+
+			// Replace the existing content of the table body with the new <tbody> elements
+			tableBody.innerHTML = "";
+			newTbodies.forEach((newTbody) => {
+				tableBody.appendChild(newTbody);
+			});
 		}
 	};
 
@@ -388,6 +417,9 @@
 	<style>
 		.d-none {
 			display: none;
+		}
+		#oldTbody .handle {
+			cursor: grab;
 		}
 	</style>
 {% endblock %}


### PR DESCRIPTION
Changes Made:

Database Schema Changes:

Added a position column in the label_stub table to store the order of stubs within each label.
Introduced a stubsOrder column in the scheme table to persist the overall order of stubs within a scheme.

Functionality Changed:
Added the drag n drop sorting for stubs in label edit page and in scheme creation and editing and persisting these orders with saving for later use in pdf or html reports 