### PR TITLE
Removing the stub name from the generated HTML and PDF

### DIFF
--- a/src/Service/SchemeService.php
+++ b/src/Service/SchemeService.php
@@ -246,9 +246,6 @@ class SchemeService
       }
    
       $newTbody .= '<tr id="rowLabel|' . $label->getId() . '|stub|' . $stub->getId() . '">' .
-        '<td class="col-2">' .
-        $stub->getName() .
-        '</td>' .
         $descriptionExcerptItem .
         '</tr>';
   


### PR DESCRIPTION
**The generated HTML:**
![image](https://github.com/pmeng/therapy-scheme-generator/assets/47036731/a574a77d-6719-4399-b03a-46469174a4b7)
**The generated PDF:**
![image](https://github.com/pmeng/therapy-scheme-generator/assets/47036731/c60775e5-35a6-47e9-bed5-68e2a065b844)
