### PR TITLE
Adding delete, and mark as deleted in therapy scheme button

### DIFF
--- a/migrations/Version20241029083645.php
+++ b/migrations/Version20241029083645.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20241029083645 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE stub ADD is_marked TINYINT(1) DEFAULT NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE stub DROP is_marked');
+    }
+}

--- a/src/Controller/Therapy/StubController.php
+++ b/src/Controller/Therapy/StubController.php
@@ -54,6 +54,9 @@ class StubController extends AbstractController
             $query->andWhere($query->expr()->orX(
                 $query->expr()->isNull('stub.isDeleted'),
                 $query->expr()->eq('stub.isDeleted', 0)
+            ))->andWhere($query->expr()->orX(
+                $query->expr()->isNull('stub.isMarked'),
+                $query->expr()->eq('stub.isMarked', 0)
             ));
         }
 
@@ -131,6 +134,9 @@ class StubController extends AbstractController
             $query->andWhere($query->expr()->orX(
                 $query->expr()->isNull('stub.isDeleted'),
                 $query->expr()->eq('stub.isDeleted', 0)
+            ))->andWhere($query->expr()->orX(
+                $query->expr()->isNull('stub.isMarked'),
+                $query->expr()->eq('stub.isMarked', 0)
             ));
         }
         
@@ -264,7 +270,23 @@ class StubController extends AbstractController
             return $this->redirectToRoute('app_therapy_stubs_list');
         }
 
+        $stub->setIsMarked(!$stub->getIsDeleted());
         $stub->setIsDeleted(!$stub->getIsDeleted());
+        $this->entityManager->persist($stub);
+        $this->entityManager->flush();
+
+        return $this->redirectToRoute('app_therapy_stubs_list');
+    }
+
+    #[Route('/{_locale<%app.supported_locales%>}/therapy/stub/markUnmark/{id<\d+>}', name: 'app_therapy_stub_mark_unmark')]
+    public function markUnmarkStub(int $id, StubRepository $stubRepository): Response
+    {
+        $stub = $stubRepository->find($id);
+        if ($stub === null) {
+            return $this->redirectToRoute('app_therapy_stubs_list');
+        }
+
+        $stub->setIsMarked(!$stub->getIsMarked());
         $this->entityManager->persist($stub);
         $this->entityManager->flush();
 
@@ -291,6 +313,10 @@ class StubController extends AbstractController
             ->andWhere($query->expr()->orX(
                 $query->expr()->isNull('stub.isDeleted'),
                 $query->expr()->eq('stub.isDeleted', 0)
+            ))
+            ->andWhere($query->expr()->orX(
+                $query->expr()->isNull('stub.isMarked'),
+                $query->expr()->eq('stub.isMarked', 0)
             ))
             ->getQuery()
             ->getResult()

--- a/src/Entity/Therapy/Stub.php
+++ b/src/Entity/Therapy/Stub.php
@@ -31,6 +31,9 @@ class Stub
     #[ORM\Column(type: 'boolean', nullable: true)]
     private ?bool $isDeleted;
 
+    #[ORM\Column(type: 'boolean', nullable: true)]
+    private ?bool $isMarked;
+
     #[ORM\ManyToOne(targetEntity: StubCategory::class, inversedBy: "stubs")]
     #[ORM\JoinColumn(nullable: true)]
     private ?StubCategory $category;
@@ -111,6 +114,17 @@ class Stub
     {
         $this->isDeleted = $isDeleted;
 
+        return $this;
+    }
+
+    public function getIsMarked(): ?bool
+    {
+        return $this->isMarked;
+    }
+
+    public function setIsMarked(bool $isMarked): self
+    {
+        $this->isMarked = $isMarked;
         return $this;
     }
 

--- a/src/Repository/Therapy/StubRepository.php
+++ b/src/Repository/Therapy/StubRepository.php
@@ -147,7 +147,7 @@ class StubRepository extends ServiceEntityRepository
         $qb->select('s')
             ->from('App\Entity\Therapy\Scheme', 's')
             ->where($qb->expr()->like('s.targets', ':stubId'))
-            ->setParameter('stubId', '%stubID=' . $stubId . '%');
+            ->setParameter('stubId', '%stubID=' . $stubId . '"%');
         
         return $qb->getQuery()->getResult();
     }

--- a/src/Service/SchemeService.php
+++ b/src/Service/SchemeService.php
@@ -182,32 +182,35 @@ class SchemeService
           $excerptItemClass .= ' d-none';
         }
 
-        $newTbody .= '<tr id="rowLabel|' . $label->getId() . '|stub|' . $stub->getId() . '">' .
-          '<td class="text-end col-2">' .
-          $checkboxInput .
-          '</td>' .
-          '<td class="col-2">' .
-          $stub->getName() .
-          '</td>' .
-          '<td class="' . $descriptionItemClass . '">' .
-          substr($stub->getDescription(), 0, 40) .
-          '</td>' .
-          '<td class="' . $excerptItemClass . '">' .
-          substr($stub->getExcerpt(), 0, 40) .
-          '</td>' .
-          '<td class="col-2">' .
-          substr($stub->getBackground(), 0, 300) .
-          '</td>' .
-          '<td class="border-start col-2">' .
-          $textArea .
-          '</td>' .
-          '<td class="col-1.5">' .
-          $labelNames .
-          '</td>' .
-          '<td>' .
-          $trashIcon .
-          '</td>' .
-          '</tr>';
+        $newTbody .= '<tr id="rowLabel|' . $label->getId() . '|stub|' . $stub->getId() . '" ' .
+        ($stub->getIsMarked() || $stub->getIsDeleted() ? 'class="table-danger"' : '') . // Apply red color if isMarked is 1
+        '>' .
+        '<td class="text-end col-2">' .
+        $checkboxInput .
+        '</td>' .
+        '<td class="col-2">' .
+        $stub->getName() .
+        '</td>' .
+        '<td class="' . $descriptionItemClass . '">' .
+        substr($stub->getDescription(), 0, 40) .
+        '</td>' .
+        '<td class="' . $excerptItemClass . '">' .
+        substr($stub->getExcerpt(), 0, 40) .
+        '</td>' .
+        '<td class="col-2">' .
+        substr($stub->getBackground(), 0, 300) .
+        '</td>' .
+        '<td class="border-start col-2">' .
+        $textArea .
+        '</td>' .
+        '<td class="col-1.5">' .
+        $labelNames .
+        '</td>' .
+        '<td>' .
+        $trashIcon .
+        '</td>' .
+        '</tr>';
+      
         }
       }
 

--- a/templates/therapy/stub/index.html.twig
+++ b/templates/therapy/stub/index.html.twig
@@ -57,27 +57,34 @@
         {% if stub %}
             <form action="{{ path('app_therapy_stub_delete_undelete', {'id': stub.id}) }}" method="post" id="deleteUndoForm">
             </form>
+            <form action="{{ path('app_therapy_stub_mark_unmark', {'id': stub.id}) }}" method="post" id="markUndoForm">
+            </form>
         {% endif %}
 
 </div>
-
-    <div class="modal fade" id="confirmModal" tabindex="-1" aria-labelledby="confirmModalLabel" aria-hidden="true">
-        <div class="modal-dialog modal-dialog-centered">
-            <div class="modal-content">
-                <div class="modal-header bg-primary text-white">
-                    <h5 class="modal-title" id="confirmModalLabel">{{ 'app-modal-stub-confirmation'|trans }}</h5>
-                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="{{ 'app-modal-close'|trans }}"></button>
-                </div>
-                <div class="modal-body">
-                    <div id="relatedSchemes"></div>
-                </div>
-                <div class="modal-footer">
-                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">{{ 'app-cancel-button'|trans }}</button>
-                    <button type="button" id="confirmDelete" class="btn btn-danger">{{ 'app-delete-button'|trans }}</button>
+    {% if stub %}
+        <div class="modal fade" id="confirmModal" tabindex="-1" aria-labelledby="confirmModalLabel" aria-hidden="true">
+            <div class="modal-dialog modal-dialog-centered">
+                <div class="modal-content">
+                    <div class="modal-header bg-primary text-white">
+                        <h5 class="modal-title" id="confirmModalLabel">{{ 'app-modal-stub-confirmation'|trans }}</h5>
+                        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="{{ 'app-modal-close'|trans }}"></button>
+                    </div>
+                    <div class="modal-body">
+                        <div id="relatedSchemes"></div>
+                    </div>
+                    <div class="modal-footer">
+                        <button type="button" id="confirmDelete" class="btn btn-danger">{{ 'app-delete-button'|trans }}</button>
+                        <button id="markAsDeleted" class="btn btn-danger" type="button" data-bs-toggle="modal" >
+                            {% if stub.isMarked %}{{ 'app-unmark-as-deleted-button'|trans }}{% else %}{{ 'app-mark-as-deleted-button'|trans }}{% endif %}
+                        </button>
+                        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">{{ 'app-cancel-button'|trans }}</button>
+                    </div>
                 </div>
             </div>
         </div>
-    </div>
+    {% endif %}
+
 {% endblock %}
 
 {% block javascripts %}
@@ -143,7 +150,10 @@
         {% if stub %}
             const deleteButton = document.getElementById('deleteUndoBTN');
             const confirmDeleteButton = document.getElementById('confirmDelete');
+            const markAsDeletedButton = document.getElementById('markAsDeleted');
+
             const isDeleted = {% if stub.isDeleted %}true{% else %}false{% endif %};
+            const isMarked = {% if stub.isMarked %}true{% else %}false{% endif %};
 
             const notUsedInScheme = {% if usedSchemes == [] %}true{% else %}false{% endif %};
 
@@ -179,6 +189,9 @@
                 
                 confirmDeleteButton.addEventListener('click', function () {
                     document.getElementById('deleteUndoForm').submit();
+                });
+                markAsDeletedButton.addEventListener('click', function () {
+                    document.getElementById('markUndoForm').submit();
                 });
             }
         {% endif %}

--- a/translations/messages.de.xlf
+++ b/translations/messages.de.xlf
@@ -189,6 +189,14 @@
         <source>app-delete-button</source>
         <target>Löschen</target>
       </trans-unit>
+      <trans-unit id="XKdvd3f" resname="app-mark-as-deleted-button">
+        <source>app-mark-as-deleted-button</source>
+        <target>In Therapieschemata als gelöscht markieren</target>
+      </trans-unit>
+      <trans-unit id="XKvra3f" resname="app-unmark-as-deleted-button">
+        <source>app-unmark-as-deleted-button</source>
+        <target>Markierung als gelöscht in Therapieplänen aufheben</target>
+      </trans-unit>
       <trans-unit id="8Kdvlxd" resname="app-undelete-button">
         <source>app-undelete-button</source>
         <target>Wiederherstellen</target>

--- a/translations/messages.en.xlf
+++ b/translations/messages.en.xlf
@@ -201,6 +201,14 @@
         <source>app-delete-button</source>
         <target>Delete</target>
       </trans-unit>
+      <trans-unit id="XKdvd3f" resname="app-mark-as-deleted-button">
+        <source>app-mark-as-deleted-button</source>
+        <target>Mark as deleted in therapy schemes</target>
+      </trans-unit>
+      <trans-unit id="XKvra3f" resname="app-unmark-as-deleted-button">
+        <source>app-unmark-as-deleted-button</source>
+        <target>Unmark as deleted in therapy schemes</target>
+      </trans-unit>
       <trans-unit id="8Kdvlxd" resname="app-undelete-button">
         <source>app-undelete-button</source>
         <target>Undelete</target>


### PR DESCRIPTION
adding delete and mark as deleted in therapy scheme as if the stub is deleted and it is used in a therapy scheme would be marked with red color and allow the stub to be deleted as this would make it doesn't appear in stub list page and in stub search output in the therapy scheme page